### PR TITLE
Bug 42975: Panopto Watch Folder Service is case-sensitive. Doesn't uppercase .MOV files

### DIFF
--- a/WatchFolderService/Properties/AssemblyInfo.cs
+++ b/WatchFolderService/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.3.0")]
-[assembly: AssemblyFileVersion("1.1.3.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]

--- a/WatchFolderService/WatchFolderService.cs
+++ b/WatchFolderService/WatchFolderService.cs
@@ -539,7 +539,7 @@ namespace WatchFolderService
             {
                 foreach (string ext in extensions)
                 {
-                    if (fileInfo.Extension.Equals(ext) && IsFileAccessible(fileInfo))
+                    if (fileInfo.Extension.Equals(ext, StringComparison.OrdinalIgnoreCase) && IsFileAccessible(fileInfo))
                     {
                         resultArray.Add(fileInfo);
                         break;

--- a/WatchFolderService/WatchFolderService.cs
+++ b/WatchFolderService/WatchFolderService.cs
@@ -30,7 +30,7 @@ namespace WatchFolderService
         private Thread workerThread = null;
         private ManualResetEvent stopRequested = null;
         private int fileWaitTime = 60;
-        private long defaultPartsize = 1048576;
+        private long defaultPartsize = 6000000;
         private string[] extensions;
         private bool inputValid = true;
         private string inputFailureMessage = "";
@@ -162,7 +162,7 @@ namespace WatchFolderService
             serviceStatus.dwWaitHint = 100000;
             SetServiceStatus(this.ServiceHandle, ref serviceStatus);
 
-            this.EventLog.WriteEntry("Service Started Successfully"); // Event Log Record
+            this.EventLog.WriteEntry("Service Started Successfully. Version=" + typeof(WatchFolderService).Assembly.GetName().Version);
 
             // Check input values
             bool hasInvalidInput = false;

--- a/WatchFolderServiceInstaller/Product.wxs
+++ b/WatchFolderServiceInstaller/Product.wxs
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-	<Product Id="*" Name="Panopto Watch Folder Service" Version="1.1.3.0" Manufacturer="Panopto" Language="1033" UpgradeCode="841957fd-9904-43a3-8c78-84b9a7c8219e">
+	<Product Id="*" Name="Panopto Watch Folder Service" Version="1.2.0.0" Manufacturer="Panopto" Language="1033" UpgradeCode="841957fd-9904-43a3-8c78-84b9a7c8219e">
 		<Package InstallerVersion="300" Compressed="yes" InstallScope="perMachine" />
     <Media Id="1" Cabinet="Cab1.cab" EmbedCab="yes" />
 


### PR DESCRIPTION
Bug 42975: Panopto Watch Folder Service is case-sensitive. Doesn't uppercase .MOV files
Update version to 1.2.0.0.
Add version number in the start up event log entry.

workitem: 42975
